### PR TITLE
fix bug reported in issue #117 with data.table

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pRolocGUI
 Title: Interactive visualisation of spatial proteomics data
-Version: 2.11.0
+Version: 2.11.1
 Authors@R: c(person(given = "Lisa", family ="Breckels",
                     email = "lms79@cam.ac.uk",
                     comment = c(ORCID = "0000-0001-8918-7171"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,12 +3,16 @@
 ## CHANGES IN VERSION 2.11.0
 - New version for Bioc devel
 
+## CHANGES IN VERSION 2.11.1
+- Fix bug in DT table when fData column is a matrix see
+  issue #117
+
 # pRolocGUI 2.10
 
 ## CHANGES IN VERSION 2.8.0
 - Bioconductor release 3.17
 
-# pRolocGUI 2.9.0
+# pRolocGUI 2.9
 
 ## CHANGES IN VERSION 2.9.0
 - New version for Bioc 3.17 

--- a/R/pRolocVis_aggregation.R
+++ b/R/pRolocVis_aggregation.R
@@ -79,8 +79,8 @@ pRolocVis_aggregate <- function(object,
 
   ## Make any columns in the fData that are a matrix a vector 
   ## (we need to do this to make sure the table is displayed properly)
-  peps <- .makeMatsVecs(peps)
-  prots <- .makeMatsVecs(prots)
+  peps <- .convertMatsToCols(peps)
+  prots <- .convertMatsToCols(prots)
   
   
   ## Extract binary matrix (pmarkers) for the peptide MSnSet for markers

--- a/R/pRolocVis_compare.R
+++ b/R/pRolocVis_compare.R
@@ -144,21 +144,22 @@ pRolocVis_compare <- function(object,
   ## to vectors as otherwise in the shiny app these are displayed as
   ## a long vector of 1,0,0,0,0,1,0 etc
   for (i in seq(object)) {
-    .tn <- length(fvarLabels(object[[i]]))
-    chk <- vector(length = .tn)
-    for (j in 1:.tn) {
-      chk[j] <- is.matrix(fData(object[[i]])[, j])
-    }
-    if (any(chk)) {
-      .ind <- which(chk)
-      .nams <- fvarLabels(object[[i]])[.ind]
-      .tmpnams <- paste0(.nams, format(Sys.time(), "%a%b%d%H%M%S%Y"))
-      for (j in seq(.nams)) {
-        object[[i]] <- mrkMatToVec(object[[i]], mfcol = .nams[j], vfcol = .tmpnams[j])
-      }
-      fData(object[[i]])[, .nams] <- NULL
-      fvarLabels(object[[i]])[match(.tmpnams, fvarLabels(object[[i]]))] <- .nams
-    }
+    object@x[[i]] <- .convertMatsToCols(object[[i]])
+    # .tn <- length(fvarLabels(object[[i]]))
+    # chk <- vector(length = .tn)
+    # for (j in 1:.tn) {
+    #   chk[j] <- is.matrix(fData(object[[i]])[, j])
+    # }
+    # if (any(chk)) {
+    #   .ind <- which(chk)
+    #   .nams <- fvarLabels(object[[i]])[.ind]
+    #   .tmpnams <- paste0(.nams, format(Sys.time(), "%a%b%d%H%M%S%Y"))
+    #   for (j in seq(.nams)) {
+    #     object[[i]] <- mrkMatToVec(object[[i]], mfcol = .nams[j], vfcol = .tmpnams[j])
+    #   }
+    #   fData(object[[i]])[, .nams] <- NULL
+    #   fvarLabels(object[[i]])[match(.tmpnams, fvarLabels(object[[i]]))] <- .nams
+    # }
   }
   
   

--- a/R/pRolocVis_explore.R
+++ b/R/pRolocVis_explore.R
@@ -150,25 +150,25 @@ pRolocVis_explore <- function(object,
   }
   
 
-  ## Update feature data and convert any columns that are matrices
-  ## to vectors as otherwise in the shiny app these are displayed as
-  ## a long vector of 1,0,0,0,0,1,0 etc.
-  .tn <- length(fvarLabels(object))
-  chk <- vector(length = .tn)
-  for (i in 1:.tn) {
-    chk[i] <- is.matrix(fData(object)[, i])
-  }
-  if (any(chk)) {
-    .ind <- which(chk)
-    .nams <- fvarLabels(object)[.ind]
-    .tmpnams <- paste0(.nams, format(Sys.time(), "%a%b%d%H%M%S%Y"))
-    for (i in seq(.nams)) {
-      object <- mrkMatToVec(object, mfcol = .nams[i], vfcol = .tmpnams[i])
-    }
-    fData(object)[, .nams] <- NULL
-    fvarLabels(object)[match(.tmpnams, fvarLabels(object))] <- .nams
-  }
-  
+  # ## Update feature data and convert any columns that are matrices
+  # ## to vectors as otherwise in the shiny app these are displayed as
+  # ## a long vector of 1,0,0,0,0,1,0 etc.
+  # .tn <- length(fvarLabels(object))
+  # chk <- vector(length = .tn)
+  # for (i in 1:.tn) {
+  #   chk[i] <- is.matrix(fData(object)[, i]) | is.data.frame(fData(object)[, i])
+  # }
+  # if (any(chk)) {
+  #   .ind <- which(chk)
+  #   .nams <- fvarLabels(object)[.ind]
+  #   .tmpnams <- paste0(.nams, format(Sys.time(), "%a%b%d%H%M%S%Y"))
+  #   for (i in seq(.nams)) {
+  #     object <- mrkMatToVec(object, mfcol = .nams[i], vfcol = .tmpnams[i])
+  #   }
+  #   fData(object)[, .nams] <- NULL
+  #   fvarLabels(object)[match(.tmpnams, fvarLabels(object))] <- .nams
+  # }
+  object <- .convertMatsToCols(object)
   
   ## Now extract all relevant data
   fd <- fData(object)                             # all featureData

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,22 +1,22 @@
-# ## Update feature data and convert any columns that are matrices to
-# ## vectors as otherwise in the shiny app these are displayed as a long
-# ## vector of (1, 0, 0, 0, 0, 1, 0) etc.
-.makeMatsVecs <- function(msnset) {
+## Update feature data and convert any columns that are matrices into additional
+## explicit columns in the data.table in the app. Otherwise DT crashes
+.convertMatsToCols <- function(msnset) {
   .tn <- length(fvarLabels(msnset))
   chk <- vector(length = .tn)
   for (i in 1:.tn) {
-    chk[i] <- is.matrix(fData(msnset)[, i])
+    chk[i] <- is.matrix(fData(msnset)[, i]) | is.data.frame(fData(msnset)[, i])
   }
   if (any(chk)) {
     .ind <- which(chk)
     .nams <- fvarLabels(msnset)[.ind]
-    .tmpnams <- paste0(.nams, format(Sys.time(), "%a%b%d%H%M%S%Y"))
     for (i in seq(.nams)) {
-      msnset <- pRoloc::mrkMatToVec(msnset, mfcol = .nams[i],
-                                    vfcol = .tmpnams[i])
+      .df <- fData(msnset)[, .nams[i]]
+      .newNams <- paste0(.nams[i], ".", colnames(.df))
+      colnames(.df) <- .newNams
+      fData(msnset) <- cbind(fData(msnset), .df)
     }
-    fData(msnset)[, .nams] <- NULL
-    fvarLabels(msnset)[match(.tmpnams, fvarLabels(msnset))] <- .nams
+    fData(msnset) <- fData(msnset)[, -.ind]
+    
   }
   return(msnset)
 }


### PR DESCRIPTION
This PR fixes and addresses issue #117. Specifically,
- A new function `convertMatsToCols` has been added which checks the `fData` for any columns that may be a matrix e.g. TAGM joint probability results, and then explicitly adds the columns of the matrix to the `fData` of the `MSnSet` object
- The columns of the matrix can now be explictly selected in the "Table Selection" tab of the GUI
- The function `makeMatsVecs` has been removed as is redundant 